### PR TITLE
Enables OIDC for NPM package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# This workflow will publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# This workflow will publish a package to the NPM registry when a release is created.
+# It uses npm Trusted Publishing (OIDC) instead of a long-lived NPM_TOKEN secret.
+# See: https://docs.npmjs.com/trusted-publishers/
 
 name: Publish package to NPM repository
 on:
@@ -9,6 +10,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC / Trusted Publishing
     steps:
       - uses: actions/checkout@v4
         with:
@@ -17,8 +21,8 @@ jobs:
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
+      # Trusted Publishing requires npm 11.5.1 or later.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build-ts
       - run: npm publish --tag latest --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Updates the release workflow to use npm Trusted Publishing (OpenID Connect) for authenticating with the NPM registry. This enhances security by removing the dependency on a long-lived `NPM_TOKEN` secret.

The change involves adding `id-token: write` permissions to the workflow and ensuring the latest npm version is installed, which is a prerequisite for Trusted Publishing.